### PR TITLE
chore: even more faster profile resolving

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -361,7 +361,7 @@ module Match
       portal_profile = all_profiles.detect { |i| i.uuid == uuid }
 
       if portal_profile
-        profile_device_count = portal_profile.fetch_all_devices.count
+        profile_device_count = portal_profile.devices.count
 
         device_classes =
           case platform
@@ -444,7 +444,7 @@ module Match
       #   * For portal certificates, we filter out the expired one but includes a new certificate;
       #   * Profile still contains an expired certificate and is valid.
       # Thus, we need to check the validity of profile certificates too.
-      profile_certs_count = portal_profile.fetch_all_certificates.select(&:valid?).count
+      profile_certs_count = portal_profile.certificates.select(&:valid?).count
 
       certificate_types =
         case platform

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -360,7 +360,7 @@ describe Match do
 
       before do
         allow(profile).to receive(:uuid).and_return(uuid)
-        allow(profile).to receive(:fetch_all_devices).and_return([profile_device])
+        allow(profile).to receive(:devices).and_return([profile_device])
       end
 
       it "device is enabled" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Faster match 😅.

### Description
match performs `fetch_all_*` requests instead of using just fetched and included devices and certificates in the fetched profile.
